### PR TITLE
Argparser release (0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ Learn more about the philosophy and format of this file in [VERSIONING](./VERSIO
 ### Added
 `+` New namespace created: `Dialogue.Commandline`  
 `+` New message source created: `Commandline`  
-`^+` `ArgumentManager` static class with methods for handling command line arguments  
+`+` `ArgumentManager` static class with methods for handling command line arguments  
+`+` `Argument` class to describe the metadata and state of an argument  
+`^+` A prepopulated list of `Argument`s.  
 `^+` `Parse` static method for loading an array of command line arguments into a dictionary of keyword arguments  
 `^+` `Validate` static method for checking the validity of the loaded dictionary (presence of required arguments, malformed arguments that don't match any supported option, invalid argument values), issuing errors for invalid required arguments and warnings for invalid optional arguments  
 `^+` `GetArgumentOrDefault` retrieves the value of an argument if it's valid, or a default value otherwise.
@@ -14,6 +16,9 @@ Learn more about the philosophy and format of this file in [VERSIONING](./VERSIO
 ### Changed
 `/` After catching a fatal exception, the program will immediately exit with a non-zero exit code (`1`) as opposed to coming out of the catch block and exiting with a misleading "success" code (`0`)  
 `/` Updated the repository link because of new GitHub username (Ghostling225 -> AbsoluteWisp)
+
+### Fixed
+`*` Fixed source file indents using spaces instead of tabs
 
 ## Logging - version 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,10 @@ Learn more about the philosophy and format of this file in [VERSIONING](./VERSIO
 `+` New namespace created: `Dialogue.Commandline`  
 `+` New message source created: `Commandline`  
 `+` `ArgumentManager` static class with methods for handling command line arguments  
-`+` `Argument` class to describe the metadata and state of an argument  
-`^+` A prepopulated list of `Argument`s.  
-`^+` `Parse` static method for loading an array of command line arguments into a dictionary of keyword arguments  
-`^+` `Validate` static method for checking the validity of the loaded dictionary (presence of required arguments, malformed arguments that don't match any supported option, invalid argument values), issuing errors for invalid required arguments and warnings for invalid optional arguments  
-`^+` `GetArgumentOrDefault` retrieves the value of an argument if it's valid, or a default value otherwise.
+`+` `Argument` class to describe the metadata and state of an argument (default and provided values, description, name, etc.)  
+`+` A prepopulated list of `Argument`s (for now only a "minimum log level to show" argument).  
+`+` `Parse` static method for loading an array of command line arguments into a dictionary of keyword arguments (`string` -> `Argument`)  
+`+` `GetArgument` static method retrieves the value of an argument, with defaults available for optional arguments.
 
 ### Changed
 `/` After catching a fatal exception, the program will immediately exit with a non-zero exit code (`1`) as opposed to coming out of the catch block and exiting with a misleading "success" code (`0`)  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Learn more about the philosophy and format of this file in [VERSIONING](./VERSIO
 `+` New message source created: `Commandline`  
 `^+` `ArgumentManager` static class with methods for handling command line arguments  
 `^+` `Parse` static method for loading an array of command line arguments into a dictionary of keyword arguments  
-`^+` `Validate` static method for checking the validity of specified arguments (presence of required arguments, malformed arguments that don't match any supported option, invalid argument values), issuing errors for invalid required arguments and warnings for invalid optional arguments  
+`^+` `Validate` static method for checking the validity of the loaded dictionary (presence of required arguments, malformed arguments that don't match any supported option, invalid argument values), issuing errors for invalid required arguments and warnings for invalid optional arguments  
 `^+` `GetArgumentOrDefault` retrieves the value of an argument if it's valid, or a default value otherwise.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,27 @@
 # Changelog
 Learn more about the philosophy and format of this file in [VERSIONING](./VERSIONING.md)
 
+## \[EDGE\] ArgParser - to be version 0.2.0
+
+### Added
+`+` New namespace created: `Dialogue.Commandline`  
+`+` New message source created: `Commandline`  
+`^+` `ArgumentManager` static class with methods for handling command line arguments  
+`^+` `Parse` static method for loading an array of command line arguments into a dictionary of keyword arguments  
+`^+` `Validate` static method for checking the validity of specified arguments (presence of required arguments, malformed arguments that don't match any supported option, invalid argument values), issuing errors for invalid required arguments and warnings for invalid optional arguments  
+`^+` `GetArgumentOrDefault` retrieves the value of an argument if it's valid, or a default value otherwise.
+
+### Changed
+`/` After catching a fatal exception, the program will immediately exit with a non-zero exit code (`1`) as opposed to coming out of the catch block and exiting with a misleading "success" code (`0`)  
+`/` Updated the repository link because of new GitHub username (Ghostling225 -> AbsoluteWisp)
+
 ## Logging - version 0.1.0
 
 ### Added
-`+ Source files are now organised into namespaces. Directory structure reflects C# namespaces.`  
-`+ New namespace created: Dialogue.Logging`  
-`+ Message severity enumeration describing severity of a given log message`  
-`+ Message source enumeration describing the source of a given log message in terms of major components`  
-`+ Logger static class for console logging`  
-`+ Logger method for printing text messages`  
-`+ Logger method for printing exceptions`
+`+` Source files are now organised into namespaces. Directory structure reflects C# namespaces.  
+`+` New namespace created: `Dialogue.Logging`  
+`+` Message severity enumeration describing severity of a given log message  
+`+` Message source enumeration describing the source of a given log message in terms of major components  
+`+` Logger static class for console logging  
+`+` Logger method for printing text messages  
+`+` Logger method for printing exceptions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 Learn more about the philosophy and format of this file in [VERSIONING](./VERSIONING.md)
 
-## \[EDGE\] ArgParser - to be version 0.2.0
+## ArgParser - version 0.2.0
 
 ### Added
 `+` New namespace created: `Dialogue.Commandline`  

--- a/Commandline/Argument.cs
+++ b/Commandline/Argument.cs
@@ -1,0 +1,76 @@
+using System;
+using Dialogue.Logging;
+
+namespace Dialogue.Commandline;
+
+public class Argument {
+	/// <summary>
+	/// The name of the argument, as it appears on the commandline (omitting the key prefix "--")
+	/// </summary>
+	public string Name;
+	
+	/// <summary>
+	/// The data type of this argument.
+	/// </summary>
+	public ArgumentType Type;
+
+	/// <summary>
+	/// An optional description of what this argument controls
+	/// </summary>
+	public string? Description;
+
+	/// <summary>
+	/// An optional default value for this argument to assume if no value is provided on the commandline. Leaving this blank indicates a required argument.
+	/// </summary>
+	public string? DefaultValue;
+
+	/// <summary>
+	/// The value for this argument specified by the user
+	/// </summary>
+	public string? ProvidedValue;
+
+	public Argument(string name, ArgumentType type, string? description = null, string? defaultValue = null) {
+		Name = name;
+		Type = type;
+		Description = description;
+		DefaultValue = defaultValue;
+	}
+
+	/// <summary>
+	/// Checks whether the specified value matches this argument's type and assigns it if it does. In case of mismatches emits a warning for optional arguments or an exception for required arguments.
+	/// </summary>
+	/// <param name="providedValue">The value to set</param>
+	public void SetAndValidateValue(string value) {
+		// Validation
+		switch (Type) {
+			case ArgumentType.Integer:
+				if (!int.TryParse(value, out int _)) {
+					if (DefaultValue == null) {
+						throw new ArgumentException($"Required argument {Name} is of type Integer but received a value \"{value}\" not matching that type!");
+					}
+					else {
+						Logger.Log($"Optional argument {Name} is of type Integer but received a value \"{value}\" not matching that type!", MessageSource.Commandline, MessageSeverity.Warning);
+						return;
+					}
+				}
+				break;
+			case ArgumentType.Boolean:
+				if (!(value.ToLower() == "true" || value.ToLower() == "false")) {
+					if (DefaultValue == null) {
+						throw new ArgumentException($"Required argument {Name} is of type Boolean but received a value \"{value}\" not matching that type!");
+					}
+					else {
+						Logger.Log($"Optional argument {Name} is of type Boolean but received a value \"{value}\" not matching that type!", MessageSource.Commandline, MessageSeverity.Warning);
+						return;
+					}
+				}
+				break;
+			case ArgumentType.String:
+				// Included for completeness, can't validate a string
+				break;
+		}
+
+		// If validation passed, assign the value
+		ProvidedValue = value;
+	}
+}

--- a/Commandline/Argument.cs
+++ b/Commandline/Argument.cs
@@ -7,40 +7,46 @@ public class Argument {
 	/// <summary>
 	/// The name of the argument, as it appears on the commandline (omitting the key prefix "--")
 	/// </summary>
-	public string Name;
+	public string Name { get; private set; }
 	
 	/// <summary>
 	/// The data type of this argument.
 	/// </summary>
-	public ArgumentType Type;
+	public ArgumentType Type { get; private set; }
 
 	/// <summary>
 	/// An optional description of what this argument controls
 	/// </summary>
-	public string? Description;
+	public string? Description { get; private set; }
 
 	/// <summary>
 	/// An optional default value for this argument to assume if no value is provided on the commandline. Leaving this blank indicates a required argument.
 	/// </summary>
-	public string? DefaultValue;
+	string? DefaultValue;
 
 	/// <summary>
 	/// The value for this argument specified by the user
 	/// </summary>
-	public string? ProvidedValue;
+	string? ProvidedValue;
 
 	public Argument(string name, ArgumentType type, string? description = null, string? defaultValue = null) {
-		Name = name;
+		Name = name.ToLower();
 		Type = type;
 		Description = description;
 		DefaultValue = defaultValue;
 	}
 
 	/// <summary>
-	/// Checks whether the specified value matches this argument's type and assigns it if it does. In case of mismatches emits a warning for optional arguments or an exception for required arguments.
+	/// Checks whether the specified value meets this argument's schema and sets the value if it does. When faced with type mismatches, emits warnings for optional arguments and exceptions for required ones. Protects against overwrites.
 	/// </summary>
-	/// <param name="providedValue">The value to set</param>
+	/// <param name="value">The value to set</param>
 	public void SetAndValidateValue(string value) {
+		// Overwrite protection
+		if (ProvidedValue != null) {
+			Logger.Log($"Argument {Name} already has a value \"{ProvidedValue}\" but received another value \"{value}\"! The earlier value takes precedence.", MessageSource.Commandline, MessageSeverity.Warning);
+			return;
+		}
+
 		// Validation
 		switch (Type) {
 			case ArgumentType.Integer:
@@ -49,28 +55,73 @@ public class Argument {
 						throw new ArgumentException($"Required argument {Name} is of type Integer but received a value \"{value}\" not matching that type!");
 					}
 					else {
-						Logger.Log($"Optional argument {Name} is of type Integer but received a value \"{value}\" not matching that type!", MessageSource.Commandline, MessageSeverity.Warning);
+						Logger.Log($"Optional argument {Name} is of type Integer but received a value \"{value}\" not matching that type! Assuming default \"{DefaultValue}\".", MessageSource.Commandline, MessageSeverity.Warning);
 						return;
 					}
 				}
 				break;
 			case ArgumentType.Boolean:
-				if (!(value.ToLower() == "true" || value.ToLower() == "false")) {
-					if (DefaultValue == null) {
+				value = value.ToLower().Trim();
+
+				if (!(value == "true" || value == "false")) {
+					if (DefaultValue == null) 
 						throw new ArgumentException($"Required argument {Name} is of type Boolean but received a value \"{value}\" not matching that type!");
-					}
-					else {
-						Logger.Log($"Optional argument {Name} is of type Boolean but received a value \"{value}\" not matching that type!", MessageSource.Commandline, MessageSeverity.Warning);
-						return;
-					}
+
+					Logger.Log($"Optional argument {Name} is of type Boolean but received a value \"{value}\" not matching that type! Assuming default \"{DefaultValue}\".", MessageSource.Commandline, MessageSeverity.Warning);
+					return;
 				}
 				break;
 			case ArgumentType.String:
-				// Included for completeness, can't validate a string
+				// Included to not fall into the "no validator" default, but there are no special rules to validating a string
 				break;
+			case ArgumentType.LogLevel:
+				value = value.ToLower().Trim();
+				string levelIndex = "";
+
+				switch (value) {
+					case "debug":
+						levelIndex = "0";
+						break;
+					case "info":
+						levelIndex = "1";
+						break;
+					case "warn":
+						levelIndex = "2";
+						break;
+					case "error":
+						levelIndex = "3";
+						break;
+					case "fatal":
+						levelIndex = "4";
+						break;
+					default:
+						if (DefaultValue == null) 
+						throw new ArgumentException($"Required argument {Name} is of type LogLevel but received a value \"{value}\" not matching that type!");
+
+						Logger.Log($"Optional argument {Name} is of type LogLevel but received a value \"{value}\" not matching that type! Assuming default \"{DefaultValue}\".", MessageSource.Commandline, MessageSeverity.Warning);
+						return;
+				}
+
+				value = levelIndex;
+				break;
+			default:
+				if (DefaultValue == null) 
+					throw new ArgumentException($"Required argument {Name} uses the type of \"{Type.ToString()}\", which does not have a validator!");
+
+				Logger.Log($"Optional argument {Name} uses the type of \"{Type.ToString()}\", which does not have a validator! Assuming default \"{DefaultValue}\".", MessageSource.Commandline, MessageSeverity.Warning);
+				return;
 		}
 
 		// If validation passed, assign the value
 		ProvidedValue = value;
+	}
+
+	public string GetValueOrDefault() {
+		// Use the user-provided value if present
+		if (ProvidedValue != null) return ProvidedValue;
+		// Otherwise fall back to default
+		if (DefaultValue != null) return DefaultValue;
+		// And if there is no default, throw an ArgumentException
+		throw new ArgumentException($"Attempted to access argument {Name}, but it wasn't manually set and has no default!");
 	}
 }

--- a/Commandline/ArgumentManager.cs
+++ b/Commandline/ArgumentManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using Dialogue.Logging;
@@ -5,20 +6,26 @@ using Dialogue.Logging;
 namespace Dialogue.Commandline;
 
 public static class ArgumentManager {
-	const string KEY_PREFIX = "--";
+	const string NAME_PREFIX = "--";
 
-	static Dictionary<string, string> keywordArgs = new ();
+	static readonly Dictionary<string, Argument> arguments = new () {
+		{"loglevel", new Argument("LogLevel", ArgumentType.LogLevel, "Sets the minimum level of log messages that get displayed.", "2")}
+	};
 
+	/// <summary>
+	/// Maps an array of CLI arguments to a dictionary of keyword arguments.
+	/// </summary>
+	/// <param name="args">The argument array</param>
 	public static void Parse(in string[] args) {
 		// Go through the arguments one by one        
 		for (int i = 0; i < args.Length; i++) {
 			string arg = args[i];
 			
 			// Is it a key?
-			if (arg.StartsWith(KEY_PREFIX)) {
+			if (arg.StartsWith(NAME_PREFIX)) {
 				// If it's the last arg, it's bound to be a switch
 				if (i == args.Length - 1) {
-					RegisterArgument(arg, "true");
+					RegisterArgument(arg.Substring(NAME_PREFIX.Length), "true");
 				}
 				// If not, look ahead
 				else {
@@ -26,29 +33,37 @@ public static class ArgumentManager {
 					
 					// If the next arg is already another key, this one is a switch
 					if (nextArg.StartsWith("--")) {
-						RegisterArgument(arg, "true");
+						RegisterArgument(arg.Substring(NAME_PREFIX.Length), "true");
 					}
 					// If it is a value, assign it to the current arg key and fastforward i
 					else {
-						RegisterArgument(arg, nextArg);
+						RegisterArgument(arg.Substring(NAME_PREFIX.Length), nextArg);
 						i++;
 					}
 				}
 			}
 			// If not, issue a warning. This shouldn't happen unless this code is broken or the arguments are bad.
 			else {
-				Logger.Log($"Key-less value at argument #{i + 1} (\"{arg}\"). Double check the CLI arguments. Hint: The key prefix is \"{KEY_PREFIX}\".", MessageSource.Commandline, MessageSeverity.Warning);
+				Logger.Log($"Name-less value at argument #{i + 1} (\"{arg}\")! Double check the CLI arguments. Hint: The name prefix is \"{NAME_PREFIX}\".", MessageSource.Commandline, MessageSeverity.Warning);
 			}
 		}
 	}
 
-	static void RegisterArgument(string key, string value) {
-		if (keywordArgs.ContainsKey(key)) {
-			Logger.Log($"Failed to register keyword argument \"{key}\": \"{value}\". A value for this key has already been specified (\"{keywordArgs[key]}\"). The earlier value will take precedence.", MessageSource.Commandline, MessageSeverity.Warning);
+	public static string GetArgument(string name) {
+		if (!arguments.ContainsKey(name)) {
+			throw new ArgumentException($"An attempt was made to read from nonexistent argument \"{name}\"");
+		}
+		return arguments[name].GetValueOrDefault();
+	}
+
+	static void RegisterArgument(string name, string value) {
+		// Ignore if it's not a recognised argument
+		if (!arguments.ContainsKey(name)) {
+			Logger.Log($"Failed to register keyword argument \"{name}\"! No argument is defined with this name.", MessageSource.Commandline, MessageSeverity.Warning);
 			return;
 		}
 
-		keywordArgs.Add(key, value);
-		Logger.Log($"Keyword argument registered: \"{key}\": \"{value}\"", MessageSource.Commandline);
+		// If it's a recognised name, try to save its value. The Argument class takes care of validation and overwriting.
+		arguments[name].SetAndValidateValue(value);
 	}
 }

--- a/Commandline/ArgumentManager.cs
+++ b/Commandline/ArgumentManager.cs
@@ -1,5 +1,36 @@
+using System.Collections.Generic;
+
 namespace Dialogue.Commandline;
 
 public static class ArgumentManager {
-    
+	const string KEY_PREFIX = "--";
+
+	static Dictionary<string, string> keywordArgs = new ();
+
+	public static void Parse(in string[] args) {
+		// Go through the arguments one by one        
+		for (int i = 0; i < args.Length; i++) {
+			string arg = args[i];
+			
+			// Is it a key?
+			if (arg.StartsWith(KEY_PREFIX)) {}
+				// If it's the last arg, it's bound to be a switch
+				if (i == args.Length - 1) {
+
+				}
+
+				// If not, look ahead
+					// If the next arg is a value, assign it to this key and fastforward i
+					// If not, this is a switch
+
+			// If not, what the hell just happened?
+			else {
+				Logging.Logger.Log($"Key-less value at argument #{i}. Double check the arguments. Hint: The key prefix is \"{KEY_PREFIX}\".", Logging.MessageSource.Commandline, Logging.MessageSeverity.Warning);
+			}
+		}
+	}
+
+	static void RegisterArgument(string key, string value) {
+
+	}
 }

--- a/Commandline/ArgumentManager.cs
+++ b/Commandline/ArgumentManager.cs
@@ -1,0 +1,5 @@
+namespace Dialogue.Commandline;
+
+public static class ArgumentManager {
+    
+}

--- a/Commandline/ArgumentManager.cs
+++ b/Commandline/ArgumentManager.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 
+using Dialogue.Logging;
+
 namespace Dialogue.Commandline;
 
 public static class ArgumentManager {
@@ -13,24 +15,40 @@ public static class ArgumentManager {
 			string arg = args[i];
 			
 			// Is it a key?
-			if (arg.StartsWith(KEY_PREFIX)) {}
+			if (arg.StartsWith(KEY_PREFIX)) {
 				// If it's the last arg, it's bound to be a switch
 				if (i == args.Length - 1) {
-
+					RegisterArgument(arg, "true");
 				}
-
 				// If not, look ahead
-					// If the next arg is a value, assign it to this key and fastforward i
-					// If not, this is a switch
-
-			// If not, what the hell just happened?
+				else {
+					string nextArg = args[i + 1];
+					
+					// If the next arg is already another key, this one is a switch
+					if (nextArg.StartsWith("--")) {
+						RegisterArgument(arg, "true");
+					}
+					// If it is a value, assign it to the current arg key and fastforward i
+					else {
+						RegisterArgument(arg, nextArg);
+						i++;
+					}
+				}
+			}
+			// If not, issue a warning. This shouldn't happen unless this code is broken or the arguments are bad.
 			else {
-				Logging.Logger.Log($"Key-less value at argument #{i}. Double check the arguments. Hint: The key prefix is \"{KEY_PREFIX}\".", Logging.MessageSource.Commandline, Logging.MessageSeverity.Warning);
+				Logger.Log($"Key-less value at argument #{i + 1} (\"{arg}\"). Double check the CLI arguments. Hint: The key prefix is \"{KEY_PREFIX}\".", MessageSource.Commandline, MessageSeverity.Warning);
 			}
 		}
 	}
 
 	static void RegisterArgument(string key, string value) {
+		if (keywordArgs.ContainsKey(key)) {
+			Logger.Log($"Failed to register keyword argument \"{key}\": \"{value}\". A value for this key has already been specified (\"{keywordArgs[key]}\"). The earlier value will take precedence.", MessageSource.Commandline, MessageSeverity.Warning);
+			return;
+		}
 
+		keywordArgs.Add(key, value);
+		Logger.Log($"Keyword argument registered: \"{key}\": \"{value}\"", MessageSource.Commandline);
 	}
 }

--- a/Commandline/ArgumentType.cs
+++ b/Commandline/ArgumentType.cs
@@ -1,0 +1,5 @@
+public enum ArgumentType {
+	Integer,
+	Boolean,
+	String
+}

--- a/Commandline/ArgumentType.cs
+++ b/Commandline/ArgumentType.cs
@@ -1,5 +1,9 @@
 public enum ArgumentType {
+	// Universal types
 	Integer,
 	Boolean,
-	String
+	String,
+
+	// Specialised types
+	LogLevel
 }

--- a/Dialogue.cs
+++ b/Dialogue.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 
+using Dialogue.Commandline;
+using Dialogue.Logging;
+
 namespace Dialogue;
 
 public class Dialogue {
@@ -8,13 +11,13 @@ public class Dialogue {
 
 	public static void Main(string[] args) {
 		try {
-			Logging.Logger.Log($"Dialogue {version} ({branch})", Logging.MessageSource.Core, Logging.MessageSeverity.Info);
-			Logging.Logger.Log("Help and source code: https://github.com/AbsoluteWisp/Dialogue", Logging.MessageSource.Core, Logging.MessageSeverity.Info);
+			Logger.Log($"Dialogue {version} ({branch})", MessageSource.Core, MessageSeverity.Info);
+			Logger.Log("Help and source code: https://github.com/AbsoluteWisp/Dialogue", MessageSource.Core, MessageSeverity.Info);
 
-			
+			ArgumentManager.Parse(args);
 		}
 		catch (Exception e) {
-			Logging.Logger.Log(e, Logging.MessageSource.Unknown, Logging.MessageSeverity.Fatal);
+			Logger.Log(e, MessageSource.Unknown, MessageSeverity.Fatal);
 			Environment.Exit(1);
 		}
 	}

--- a/Dialogue.cs
+++ b/Dialogue.cs
@@ -15,6 +15,7 @@ public class Dialogue {
 			Logger.Log("Help and source code: https://github.com/AbsoluteWisp/Dialogue", MessageSource.Core, MessageSeverity.Info);
 
 			ArgumentManager.Parse(args);
+			Logger.Log("Intitalised argparser", MessageSource.Core, MessageSeverity.Debug);
 		}
 		catch (Exception e) {
 			Logger.Log(e, MessageSource.Unknown, MessageSeverity.Fatal);

--- a/Dialogue.cs
+++ b/Dialogue.cs
@@ -3,18 +3,19 @@
 namespace Dialogue;
 
 public class Dialogue {
-	const string branch = "logging";
-	const string version = "0.1.0";
+	const string branch = "argparser";
+	const string version = "0.2.0";
 
 	public static void Main(string[] args) {
 		try {
 			Logging.Logger.Log($"Dialogue {version} ({branch})", Logging.MessageSource.Core, Logging.MessageSeverity.Info);
-			Logging.Logger.Log("Help and source code: https://github.com/Ghostling225/Dialogue", Logging.MessageSource.Core, Logging.MessageSeverity.Info);
+			Logging.Logger.Log("Help and source code: https://github.com/AbsoluteWisp/Dialogue", Logging.MessageSource.Core, Logging.MessageSeverity.Info);
 
-			throw new ArithmeticException("Example arithmetic exception");
+			
 		}
 		catch (Exception e) {
 			Logging.Logger.Log(e, Logging.MessageSource.Unknown, Logging.MessageSeverity.Fatal);
+			Environment.Exit(1);
 		}
 	}
 }

--- a/Logging/Logger.cs
+++ b/Logging/Logger.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 
+using Dialogue.Commandline;
+
 namespace Dialogue.Logging;
 
 public static class Logger {
@@ -28,8 +30,12 @@ public static class Logger {
 	
 	public static void Log(string message, MessageSource source = MessageSource.Unknown, MessageSeverity severity = MessageSeverity.Debug) {
 		string line = $"< {severityNames[severity]} |{sourceNames[source]} | {message}";
-		
-		ColorWriteLine(severityColors[severity], line.TrimEnd());
+
+		// Uncomment to display severity details for every evaluated message
+		// Console.WriteLine($"< idk   |logger   | MessageSev={(int)severity}, MinimalSev={ArgumentManager.GetArgument("loglevel")}");
+
+		if ((int)severity >= int.Parse(ArgumentManager.GetArgument("loglevel")))
+			ColorWriteLine(severityColors[severity], line.TrimEnd());
 	}
 
 	public static void Log(Exception e, MessageSource source = MessageSource.Unknown, MessageSeverity severity = MessageSeverity.Error) {

--- a/Logging/Logger.cs
+++ b/Logging/Logger.cs
@@ -21,8 +21,9 @@ public static class Logger {
 	};
 
 	static readonly Dictionary<MessageSource, string> sourceNames = new() {
-		{ MessageSource.Unknown, "nosource" },
-		{ MessageSource.Core,    "core    " }
+		{ MessageSource.Unknown,     "nosource" },
+		{ MessageSource.Core,        "core    " },
+		{ MessageSource.Commandline, "cmdline " }
 	};
 	
 	public static void Log(string message, MessageSource source = MessageSource.Unknown, MessageSeverity severity = MessageSeverity.Debug) {

--- a/Logging/MessageSeverity.cs
+++ b/Logging/MessageSeverity.cs
@@ -1,9 +1,9 @@
 namespace Dialogue.Logging;
 
 public enum MessageSeverity {
-    Debug,
-    Info,
-    Warning,
-    Error,
+	Debug,
+	Info,
+	Warning,
+	Error,
 	Fatal
 }

--- a/Logging/MessageSource.cs
+++ b/Logging/MessageSource.cs
@@ -6,4 +6,5 @@ namespace Dialogue.Logging;
 public enum MessageSource {
 	Unknown,
 	Core,
+	Commandline
 }

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -21,7 +21,8 @@ The different change types are:
 - `Deprecated` `~` to denote a feature to be removed in a future release
 - `Removed` `-` to denote a feature that has just been removed
 
-To further increase legibility, every change starts with a symbol specific for its change type. Every change is written in an inline code tag (`` `~ like this deprecation here` ``)
+For consistency, every change is described either as an object ("New enumeration to describe something") or as a statement ("The program will now do A instead of B").  
+To further increase legibility, every change starts with a symbol specific for its change type. Every change is written in plain text, with the starting symbol as inline code ("`~` Deprecate something")
 
 ## Example regular block
 ```md


### PR DESCRIPTION
## ArgParser - version 0.2.0

### Added
`+` New namespace created: `Dialogue.Commandline`  
`+` New message source created: `Commandline`  
`+` `ArgumentManager` static class with methods for handling command line arguments  
`+` `Argument` class to describe the metadata and state of an argument (default and provided values, description, name, etc.)  
`+` A prepopulated list of `Argument`s (for now only a "minimum log level to show" argument).  
`+` `Parse` static method for loading an array of command line arguments into a dictionary of keyword arguments (`string` -> `Argument`)  
`+` `GetArgument` static method retrieves the value of an argument, with defaults available for optional arguments.
